### PR TITLE
feat: handle exception

### DIFF
--- a/examples/ruby_example/lib/ruby_example.rb
+++ b/examples/ruby_example/lib/ruby_example.rb
@@ -7,3 +7,9 @@ module RubyExample
   # Your code goes here...
   Rutie.new(:ruby_example).init 'Init_ruby_example', __dir__
 end
+
+class RubyStore
+  def get(key)
+    rs_get(key.to_s)
+  end
+end

--- a/examples/ruby_example/lib/ruby_example.rb
+++ b/examples/ruby_example/lib/ruby_example.rb
@@ -1,8 +1,9 @@
 require "ruby_example/version"
 require 'rutie'
 
+class CcacheRedisError < StandardError; end
+
 module RubyExample
-  class Error < StandardError; end
   # Your code goes here...
   Rutie.new(:ruby_example).init 'Init_ruby_example', __dir__
 end

--- a/examples/ruby_example/spec/ruby_example_spec.rb
+++ b/examples/ruby_example/spec/ruby_example_spec.rb
@@ -17,6 +17,22 @@ RSpec.describe RubyExample do
       expect(rv).to eq nil
     end
 
+    it 'insert returns etag' do
+      etag = ruby_store.insert('some-key', true)
+      expect(etag).not_to eq nil
+      expect(etag.to_i).not_to eq 0
+    end
+
+    it 'gets return nil' do
+      rv = ruby_store.get('none-exist-key')
+      expect(rv).to eq nil
+    end
+
+    it 'get works for integer' do
+      rv = ruby_store.get(1)
+      expect(rv).to eq nil
+    end
+
     it 'works for simple obj' do
       ruby_store.insert('some-key', true)
       expect(ruby_store.get('some-key')).to eq true
@@ -72,7 +88,4 @@ RSpec.describe RubyExample do
       expect(e.class).to eq CcacheRedisError
     end
   end
-
-  # TODO
-  # ruby_store.get 1 should work :joy:
 end

--- a/examples/ruby_example/spec/ruby_example_spec.rb
+++ b/examples/ruby_example/spec/ruby_example_spec.rb
@@ -1,15 +1,20 @@
 RSpec.describe RubyExample do
-  describe 'RubyStore' do
-    let(:ruby_store) {
-      RubyStore.new("redis://127.0.0.1/")
-    }
+  let(:ruby_store) {
+    RubyStore.new("redis://127.0.0.1/")
+  }
 
+  describe 'RubyStore' do
     class Foo
       attr_reader :a, :b
 
       def initialize(a, b)
         @a, @b = a, b
       end
+    end
+
+    it 'none exist key' do
+      rv = ruby_store.get('none-exist-key')
+      expect(rv).to eq nil
     end
 
     it 'works for simple obj' do
@@ -59,4 +64,15 @@ RSpec.describe RubyExample do
       end
     end
   end
+
+  describe 'exception handling' do
+    it 'should raise redis exception' do
+      RubyStore.new("redis://-1.-1.-1.-1")
+    rescue => e
+      expect(e.class).to eq CcacheRedisError
+    end
+  end
+
+  # TODO
+  # ruby_store.get 1 should work :joy:
 end


### PR DESCRIPTION
1. Convert Rust errors to Ruby exception and raise the exception
2. Allow `get` to receive non-integer input and covert it to string in Ruby