### PR TITLE
feat: improve concurrency ability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod errors;
 pub mod in_memory_store;
+mod partitioned_hash_map;
 pub mod serializable;
 pub mod trace;

--- a/src/partitioned_hash_map.rs
+++ b/src/partitioned_hash_map.rs
@@ -21,38 +21,45 @@ impl<'a, K: 'a + Eq + Hash + core::fmt::Debug, V: Clone> PartitionedHashMap<K, V
     }
 
     pub fn insert(&self, key: K, value: V) {
-        let mut hasher = self.hasher.build_hasher();
+        let idx = self.shard_idx(&key);
 
-        key.hash(&mut hasher);
-
-        let hash = hasher.finish() as usize;
-
-        let idx = hash % 128;
-
-        let mut shard = unsafe { self.yield_write_shard(idx) };
+        let mut shard = unsafe { self._write_shard(idx) };
         shard.insert(key, value);
     }
 
     pub fn get(&self, key: K) -> Option<V> {
-        let mut hasher = self.hasher.build_hasher();
+        let idx = self.shard_idx(&key);
 
-        key.hash(&mut hasher);
-
-        let hash = hasher.finish() as usize;
-
-        let idx = hash % 128;
-        let shard = unsafe { self.yield_read_shard(idx) };
-
+        let shard = unsafe { self._read_shard(idx) };
         shard.get(&key).cloned()
     }
 
-    unsafe fn yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V>> {
+    pub fn write_guard(&'a self, key: K) -> RwLockWriteGuard<'a, HashMap<K, V>> {
+        let idx = self.shard_idx(&key);
+
+        unsafe { self._write_shard(idx) }
+    }
+
+    pub fn read_guard(&'a self, key: K) -> RwLockReadGuard<'a, HashMap<K, V>> {
+        let idx = self.shard_idx(&key);
+
+        unsafe { self._read_shard(idx) }
+    }
+
+    fn shard_idx(&self, key: &K) -> usize {
+        let mut hasher = self.hasher.build_hasher();
+        key.hash(&mut hasher);
+        let hash = hasher.finish() as usize;
+        hash % 128
+    }
+
+    unsafe fn _write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V>> {
         debug_assert!(i < self.shards.len());
 
         self.shards.get_unchecked(i).write().unwrap()
     }
 
-    unsafe fn yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V>> {
+    unsafe fn _read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V>> {
         debug_assert!(i < self.shards.len());
 
         self.shards.get_unchecked(i).read().unwrap()

--- a/src/partitioned_hash_map.rs
+++ b/src/partitioned_hash_map.rs
@@ -1,0 +1,74 @@
+use std::collections::HashMap;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use core::hash::{BuildHasher, Hash, Hasher};
+use std::collections::hash_map::RandomState;
+
+pub struct PartitionedHashMap<K, V, S> {
+    shards: Box<[RwLock<HashMap<K, V, S>>]>,
+    hasher: S,
+}
+
+impl<'a, K: 'a + Eq + Hash + core::fmt::Debug, V: Clone> PartitionedHashMap<K, V, RandomState> {
+    pub fn new() -> Self {
+        let hasher = RandomState::default();
+
+        let shards = (0..128)
+            .map(|_| RwLock::new(HashMap::with_capacity_and_hasher(0, hasher.clone())))
+            .collect();
+
+        Self { shards, hasher }
+    }
+
+    pub fn insert(&self, key: K, value: V) {
+        let mut hasher = self.hasher.build_hasher();
+
+        key.hash(&mut hasher);
+
+        let hash = hasher.finish() as usize;
+
+        let idx = hash % 128;
+
+        let mut shard = unsafe { self.yield_write_shard(idx) };
+        shard.insert(key, value);
+    }
+
+    pub fn get(&self, key: K) -> Option<V> {
+        let mut hasher = self.hasher.build_hasher();
+
+        key.hash(&mut hasher);
+
+        let hash = hasher.finish() as usize;
+
+        let idx = hash % 128;
+        let shard = unsafe { self.yield_read_shard(idx) };
+
+        shard.get(&key).cloned()
+    }
+
+    unsafe fn yield_write_shard(&'a self, i: usize) -> RwLockWriteGuard<'a, HashMap<K, V>> {
+        debug_assert!(i < self.shards.len());
+
+        self.shards.get_unchecked(i).write().unwrap()
+    }
+
+    unsafe fn yield_read_shard(&'a self, i: usize) -> RwLockReadGuard<'a, HashMap<K, V>> {
+        debug_assert!(i < self.shards.len());
+
+        self.shards.get_unchecked(i).read().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic() {
+        let map = PartitionedHashMap::new();
+        let mep_alais = &map;
+        map.insert(1, 2);
+        mep_alais.insert(2, 3);
+        assert_eq!(map.get(1).unwrap(), 2);
+    }
+}


### PR DESCRIPTION
1. employ partitioned hash map through interior unsafe for improving different keys concurrency accessing
2. adjust the locking a little bit

### Locking strategy
For `get` method, ccache requires a read lock when calls `get` and releases it after the Redis request. If it needs to update the local date, it releases the read lock and requires a write lock.

For `insert` method, it requires a write lock for the entire method which includes the Redis request.
