### PR TITLE
feat: handle same key concurrency

### DIFF
--- a/src/partitioned_hash_map.rs
+++ b/src/partitioned_hash_map.rs
@@ -34,13 +34,13 @@ impl<'a, K: 'a + Eq + Hash + core::fmt::Debug, V: Clone> PartitionedHashMap<K, V
         shard.get(&key).cloned()
     }
 
-    pub fn write_guard(&'a self, key: K) -> RwLockWriteGuard<'a, HashMap<K, V>> {
-        let idx = self.shard_idx(&key);
+    pub fn write_guard(&'a self, key: &K) -> RwLockWriteGuard<'a, HashMap<K, V>> {
+        let idx = self.shard_idx(key);
 
         unsafe { self._write_shard(idx) }
     }
 
-    pub fn read_guard(&'a self, key: K) -> RwLockReadGuard<'a, HashMap<K, V>> {
+    pub fn read_guard(&'a self, key: &K) -> RwLockReadGuard<'a, HashMap<K, V>> {
         let idx = self.shard_idx(&key);
 
         unsafe { self._read_shard(idx) }


### PR DESCRIPTION
Ccache requests Redis when querying due to the need to do Etag comparing in the remote server. The request may take more than 1 ms due to network delay. This PR implements bach likes optimization for the same key concurrency request.

When querying the same key, only the first query requests Redis and all other requests wait for the first query's result.

The first query creates `condvar` and performs the request. Other requests wait for the first query's result through the `condvar`.