### PR TITLE
refactor: when local doesn't have cache, query redis through empty etag

### DIFF
--- a/src/partitioned_hash_map.rs
+++ b/src/partitioned_hash_map.rs
@@ -20,20 +20,6 @@ impl<'a, K: 'a + Eq + Hash + core::fmt::Debug, V: Clone> PartitionedHashMap<K, V
         Self { shards, hasher }
     }
 
-    pub fn insert(&self, key: K, value: V) -> Option<V> {
-        let idx = self.shard_idx(&key);
-
-        let mut shard = unsafe { self._write_shard(idx) };
-        shard.insert(key, value)
-    }
-
-    pub fn get(&self, key: K) -> Option<V> {
-        let idx = self.shard_idx(&key);
-
-        let shard = unsafe { self._read_shard(idx) };
-        shard.get(&key).cloned()
-    }
-
     pub fn get_through_shard(
         &self,
         key: &K,


### PR DESCRIPTION
In Redis, the get by Etag is executed through Lua script which is slower than Redis command. But it makes the code much more lean.

Considering, ccache should have a high local hit rate, this change should not affect overall performance much.